### PR TITLE
digitalTimer.css is edited

### DIFF
--- a/css/digitalTimer.css
+++ b/css/digitalTimer.css
@@ -8,6 +8,7 @@
 /* .main { */
 #digital {
   background-color: aquamarine;
+  text-align: center;
 }
 
 .reset {
@@ -17,7 +18,3 @@
   font-size: 2.5vh;
 }
 
-body {
-  background-color: bisque;
-  text-align: center;
-}


### PR DESCRIPTION
Text-align property has been removed from body element in digitalTimer.css and added in the class digital.